### PR TITLE
feat: 升级jdk镜像 #46

### DIFF
--- a/base/jdk.Dockerfile
+++ b/base/jdk.Dockerfile
@@ -2,11 +2,11 @@ FROM blueking/centos
 
 LABEL maintainer="Tencent BlueKing Devops"
 
-ENV JAVA_HOME=/usr/local/java/TencentKona-8.0.2-252
+ENV JAVA_HOME=/usr/local/java/TencentKona-8.0.15-382
 ENV PATH=$PATH:$JAVA_HOME/bin
 ENV CLASSPATH=.:${JAVA_HOME}/lib
 
-RUN wget https://github.com/Tencent/TencentKona-8/releases/download/v8.0.2-GA/TencentKona8.0.2.b1_jdk_linux-x86_64_8u252.tar.gz && \
+RUN wget https://github.com/Tencent/TencentKona-8/releases/download/8.0.15-GA/TencentKona8.0.15.b1_jdk_linux-x86_64_8u382.tar.gz && \
     mkdir /usr/local/java && \
-    tar -xvf TencentKona8.0.2.b1_jdk_linux-x86_64_8u252.tar.gz -C /usr/local/java && \
-    rm -rf TencentKona8.0.2.b1_jdk_linux-x86_64_8u252.tar.gz
+    tar -xvf TencentKona8.0.15.b1_jdk_linux-x86_64_8u382.tar.gz -C /usr/local/java && \
+    rm -rf TencentKona8.0.15.b1_jdk_linux-x86_64_8u382.tar.gz


### PR DESCRIPTION
升级到kona-jdk8最新版本[Tencent Kona v8.0.15-GA](https://github.com/Tencent/TencentKona-8/releases/tag/8.0.15-GA)